### PR TITLE
Pre-allocated readers expect readable buffers

### DIFF
--- a/bgzip/__init__.py
+++ b/bgzip/__init__.py
@@ -55,10 +55,16 @@ class BGZipReaderPreAllocated(BGZipReader):
     Inflate data into a pre-allocated buffer. The buffer size will not change, and should be large enough
     to hold at least twice the data of any call to `read`.
     """
-    def __init__(self, fileobj, buf: bytearray, num_threads=available_cores, raw_read_chunk_size=256 * 1024):
+    def __init__(self,
+                 fileobj: typing.IO,
+                 buf: memoryview,
+                 num_threads=available_cores,
+                 raw_read_chunk_size=256 * 1024):
+        if not isinstance(buf, memoryview):
+            buf = memoryview(buf)
         self.fileobj = fileobj
         self._input_data = bytes()
-        self._scratch = memoryview(buf)
+        self._scratch = buf
         self._bytes_available = 0
         self.raw_read_chunk_size = raw_read_chunk_size
 
@@ -124,8 +130,8 @@ class BGZipReaderPreAllocated(BGZipReader):
 
 class BGZipAsyncReaderPreAllocated(BGZipReaderPreAllocated):
     def __init__(self,
-                 fileobj,
-                 buf: bytearray,
+                 fileobj: typing.IO,
+                 buf: memoryview,
                  num_threads: int=available_cores,
                  raw_read_chunk_size: int=256 * 1024,
                  read_buffer_size: int=1024 * 1024):

--- a/bgzip/__init__.py
+++ b/bgzip/__init__.py
@@ -62,6 +62,8 @@ class BGZipReaderPreAllocated(BGZipReader):
                  raw_read_chunk_size=256 * 1024):
         if not isinstance(buf, memoryview):
             buf = memoryview(buf)
+        if buf.readonly:
+            raise ValueError("Expected readable buffer")
         self.fileobj = fileobj
         self._input_data = bytes()
         self._scratch = buf

--- a/tests/test_bgzip.py
+++ b/tests/test_bgzip.py
@@ -85,6 +85,9 @@ class TestBGZipReaderPreAllocated(TestBGZipReader):
         with self.subTest("Should NOT be able to pass in memoryview to bytes"):
             with self.assertRaises(ValueError):
                 self.reader_class(io.BytesIO(), b"laskdf")
+        with self.subTest("Should NOT be able to pass in non-bytes-like object"):
+            with self.assertRaises(TypeError):
+                self.reader_class(io.BytesIO(), 2)
 
 
 class TestBGZipAsyncReaderPreAllocated(TestBGZipReaderPreAllocated):

--- a/tests/test_bgzip.py
+++ b/tests/test_bgzip.py
@@ -63,8 +63,10 @@ class TestBGZipReader(unittest.TestCase):
 
 
 class TestBGZipReaderPreAllocated(TestBGZipReader):
+    reader_class = bgzip.BGZipReaderPreAllocated
+
     def _get_reader(self, handle):
-        return bgzip.BGZipReaderPreAllocated(handle, memoryview(bytearray(1024 * 1024 * 50)))
+        return self.reader_class(handle, memoryview(bytearray(1024 * 1024 * 50)))
 
     def test_read_all(self):
         with open("tests/fixtures/partial.vcf.gz", "rb") as raw:
@@ -72,9 +74,21 @@ class TestBGZipReaderPreAllocated(TestBGZipReader):
                 with self.assertRaises(TypeError):
                     fh.read()
 
+    def test_buffers(self):
+        with self.subTest("Should be able to pass in bytearray"):
+            self.reader_class(io.BytesIO(), bytearray(b"laskdf"))
+        with self.subTest("Should be able to pass in memoryview to bytearray"):
+            self.reader_class(io.BytesIO(), memoryview(bytearray(b"laskdf")))
+        with self.subTest("Should NOT be able to pass in bytes"):
+            with self.assertRaises(ValueError):
+                self.reader_class(io.BytesIO(), b"laskdf")
+        with self.subTest("Should NOT be able to pass in memoryview to bytes"):
+            with self.assertRaises(ValueError):
+                self.reader_class(io.BytesIO(), b"laskdf")
+
+
 class TestBGZipAsyncReaderPreAllocated(TestBGZipReaderPreAllocated):
-    def _get_reader(self, handle):
-        return bgzip.BGZipAsyncReaderPreAllocated(handle, memoryview(bytearray(1024 * 1024 * 50)))
+    reader_class = bgzip.BGZipAsyncReaderPreAllocated
 
 
 class TestBGZipWriter(unittest.TestCase):


### PR DESCRIPTION
- Use `memoryview` type hints for buffers
- Attempt to cast to `memoryview` if buf object is not a `memoryview`
- Make sure buf object is readable