### PR TITLE
Improve installation from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements.txt
 include bgzip_utils/*.pyx bgzip_utils/*.pxd
 include README.md
+include pyproject.toml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
+include bgzip_utils/*.pyx bgzip_utils/*.pxd
 include README.md

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ bgzip_utils.c: clean
 bgzip_utils: clean
 	BUILD_WITH_CYTHON=1 python setup.py build_ext --inplace
 
-sdist: bgzip_utils.c
-	python setup.py sdist
-
 build: version clean
 	BUILD_WITH_CYTHON=1 python setup.py bdist_wheel
+
+sdist: bgzip_utils.c
+	python setup.py sdist
 
 install: build
 	pip install --upgrade dist/*.whl
 
-.PHONY: test lint mypy tests sdist clean build install
+.PHONY: test lint mypy tests clean build sdist install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,8 @@ import platform
 from setuptools import setup, find_packages
 from distutils.extension import Extension
 
+
 install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt"))]
-
-if os.environ.get("BUILD_WITH_CYTHON"):
-    ext = ".pyx"
-else:
-    ext = ".c"
-
 
 if "Darwin" == platform.system():
     extra_compile_args = ["-O3", "-Xpreprocessor", "-fopenmp"]
@@ -19,26 +14,23 @@ else:
     extra_compile_args = ["-O3", "-fopenmp"]
     extra_link_args = ["-fopenmp"]
 
-
+file_ext = "pyx" if os.environ.get("BUILD_WITH_CYTHON") else "c"
 extensions = [
     Extension(
         name="bgzip.bgzip_utils",
-        sources=[f"bgzip_utils/bgzip_utils{ext}"],
+        sources=[f"bgzip_utils/bgzip_utils.{file_ext}"],
         libraries=["z"],
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     )
 ]
 
-
 if os.environ.get("BUILD_WITH_CYTHON"):
     from Cython.Build import cythonize
     extensions = cythonize(extensions)
 
-
 with open("README.md") as fh:
     long_description = fh.read()
-
 
 setup(
     name='bgzip',


### PR DESCRIPTION
- Bundle cython source files in sdist (accomplished in MANIFEST.in)
- Default build from sdist uses generated C file
- Build with cython using env var `BUILD_WITH_CYTHON`
- Introduce pyproject.toml to improve installation process (tells pip to automatically install setuptools and bdist_wheel)