### PR TITLE
Enable BGZipWriter to write string

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Cython is used under the hood to bypass Python's GIL and provide fast, paralleli
 
 ```
 with open("my_bgzipped_file.gz", "rb") as raw:
-	with bgzip.Reader(raw) as fh:
+	with bgzip.BGZipReader(raw) as fh:
 		data = fh.read(number_of_bytes)
 
 with open("my_bgzipped_file.gz", "wb") as raw:
-	with bgzip.Writer(raw) as fh:
+	with bgzip.BGZipWriter(raw) as fh:
 		fh.write(my_data)
 ```
 

--- a/bgzip/__init__.py
+++ b/bgzip/__init__.py
@@ -213,7 +213,8 @@ class BGZipWriter(io.IOBase):
             number_of_chunks -= batch
 
     def write(self, data):
-        self._input_buffer.extend(data)
+        _data = data.encode("utf-8") if type(data) is str else data
+        self._input_buffer.extend(_data)
         if len(self._input_buffer) > self.batch_size * bgzip_utils.block_data_inflated_size:
             self._compress()
 


### PR DESCRIPTION
This is a, possibly crude, way allow BGZipWriter to write `str`-typed data (in addition to `byte`). It refers to issue #23.

Feel free to reject it is feels dirty.