### PR TITLE
Pass size instead of whole buffer into reader

### DIFF
--- a/bgzip/__init__.py
+++ b/bgzip/__init__.py
@@ -28,18 +28,12 @@ class BGZipReader(io.IOBase):
     """
     def __init__(self,
                  fileobj: IO,
-                 buf: Optional[memoryview]=None,
+                 buffer_size: int=DEFAULT_DECOMPRESS_BUFFER_SZ,
                  num_threads=available_cores,
                  raw_read_chunk_size=256 * 1024):
-        if buf is None:
-            buf = memoryview(bytearray(DEFAULT_DECOMPRESS_BUFFER_SZ))
-        if not isinstance(buf, memoryview):
-            buf = memoryview(buf)
-        if buf.readonly:
-            raise ValueError("Expected readable buffer")
         self.fileobj = fileobj
         self._input_data = bytes()
-        self._scratch = buf
+        self._scratch = memoryview(bytearray(buffer_size))
         self._bytes_available = 0
         self.raw_read_chunk_size = raw_read_chunk_size
 

--- a/tests/test_bgzip.py
+++ b/tests/test_bgzip.py
@@ -70,21 +70,6 @@ class TestBGZipReader(unittest.TestCase):
 
         self.assertEqual(a, b)
 
-    def test_buffers(self):
-        with self.subTest("Should be able to pass in bytearray"):
-            bgzip.BGZipReader(io.BytesIO(), bytearray(b"laskdf"))
-        with self.subTest("Should be able to pass in memoryview to bytearray"):
-            bgzip.BGZipReader(io.BytesIO(), memoryview(bytearray(b"laskdf")))
-        with self.subTest("Should NOT be able to pass in bytes"):
-            with self.assertRaises(ValueError):
-                bgzip.BGZipReader(io.BytesIO(), b"laskdf")
-        with self.subTest("Should NOT be able to pass in memoryview to bytes"):
-            with self.assertRaises(ValueError):
-                bgzip.BGZipReader(io.BytesIO(), b"laskdf")
-        with self.subTest("Should NOT be able to pass in non-bytes-like object"):
-            with self.assertRaises(TypeError):
-                bgzip.BGZipReader(io.BytesIO(), 2)
-
 class TestBGZipWriter(unittest.TestCase):
     def test_write(self):
         with open("tests/fixtures/partial.vcf.gz", "rb") as raw:


### PR DESCRIPTION
This makes a simpler interface without sacrificing functionality.