### PR TITLE
Fix deflate bug for high entropy data

### DIFF
--- a/bgzip/__init__.py
+++ b/bgzip/__init__.py
@@ -101,8 +101,11 @@ class BGZipWriter(io.IOBase):
         self.fileobj = fileobj
         self.batch_size = batch_size
         self._input_buffer = bytearray()
-        block_size = bgu.block_data_inflated_size + bgu.block_metadata_size
-        self._deflated_buffers = [bytearray(block_size) for _ in range(self.batch_size)]
+
+        # Include a kilobyte of padding for poorly compressible data
+        max_deflated_block_size = bgu.block_data_inflated_size + bgu.block_metadata_size + 1024
+
+        self._deflated_buffers = [bytearray(max_deflated_block_size) for _ in range(self.batch_size)]
         self.num_threads = num_threads
 
     def writable(self):

--- a/tests/test_bgzip.py
+++ b/tests/test_bgzip.py
@@ -97,6 +97,11 @@ class TestBGZipWriter(unittest.TestCase):
         self.assertEqual(inflated_data, reinflated_data)
         self.assertTrue(fh_out.getvalue().endswith(bgzip.bgzip_eof))
 
+    def test_write_random_data(self):
+        inflated_data = os.urandom(1024 * 1024)
+        with bgzip.BGZipWriter(io.BytesIO()) as writer:
+            writer.write(inflated_data)
+
     def test_pathalogical_write(self):
         fh = io.BytesIO()
         with bgzip.BGZipWriter(fh):


### PR DESCRIPTION
Use sufficient space in the deflate output buffers to accommodate
high entropy data, which is poorly compressible. This avoids
buffer overruns.