### PR TITLE
Raise if no blocks can be inflated

### DIFF
--- a/bgzip_utils/bgzip_utils.pyx
+++ b/bgzip_utils/bgzip_utils.pyx
@@ -82,6 +82,9 @@ cdef struct chunk_s:
 class BGZIPException(Exception):
     pass
 
+class BGZIPNoChunksInflated(BGZIPException):
+    pass
+
 class BGZIPMalformedHeaderException(BGZIPException):
     pass
 
@@ -246,6 +249,9 @@ def inflate_chunks(list py_src_mem_views, object py_dst_buf, int num_threads):
             num_chunks_read += 1
             if chunks[i].src.available_in:
                 break
+
+        if not chunks[0].num_blocks:
+            raise BGZIPNoChunksInflated("Not enough space in buffer to inflate any blocks.")
 
         for i in range(num_blocks_read):
             blocks[i].next_out = dst_buf

--- a/tests/test_bgzip.py
+++ b/tests/test_bgzip.py
@@ -116,6 +116,12 @@ class TestBGZipReader(unittest.TestCase):
             _test_inflate_chunks([memoryview(b"".join(chunk))
                                   for chunk in _randomly_chunked(deflated_blocks)])
 
+        with self.subTest("too small inflate buf should raise"):
+            inflate_buf = memoryview(bytearray(1024))
+            with self.assertRaises(bgzip.bgu.BGZIPNoChunksInflated):
+                _test_inflate_chunks([memoryview(b"".join(chunk))
+                                      for chunk in _randomly_chunked(deflated_blocks)])
+
         with self.subTest("passing in non-memoryview buffers should raise"):
             with self.assertRaises(TypeError):
                 bgzip.inflate_chunks([b"asfd"], inflate_buf)


### PR DESCRIPTION
This can happen if 'inflate_buf' is too small.